### PR TITLE
Abstract Base Plugin Class Fix

### DIFF
--- a/src/main/java/net/superdark/minecraft/plugins/SuperDarkCore/registration/BaseSuperDarkPlugin.java
+++ b/src/main/java/net/superdark/minecraft/plugins/SuperDarkCore/registration/BaseSuperDarkPlugin.java
@@ -7,7 +7,7 @@ public abstract class BaseSuperDarkPlugin extends JavaPlugin
 {
     private SuperDarkCorePlugin corePlugin_;
 
-    public BaseSuperDarkPlugin(String pluginName)
+    private void register(String pluginName)
     {
         this.corePlugin_ = SuperDarkCorePlugin.getInstance();
 


### PR DESCRIPTION
The abstract java plugin class had an is not working. The class was constructed and code was ran before the core plugin instance was created.